### PR TITLE
Fix date input based calculation

### DIFF
--- a/app.py
+++ b/app.py
@@ -302,11 +302,15 @@ def main():
         ## Time range input
         with c1:
             col1, col2 = st.columns(2)
+            
+            today = datetime.today()
+            delay = today - timedelta(days=2)
+
             col1.warning("Initial NDVI Date 📅")
-            initial_date = col1.date_input("initial", label_visibility="collapsed")
+            initial_date = col1.date_input("initial", value=delay, label_visibility="collapsed")
 
             col2.success("Updated NDVI Date 📅")
-            updated_date = col2.date_input("updated", label_visibility="collapsed")
+            updated_date = col2.date_input("updated", value=delay, label_visibility="collapsed")
 
             time_range = 7
             # Process initial date

--- a/app.py
+++ b/app.py
@@ -303,15 +303,18 @@ def main():
         with c1:
             col1, col2 = st.columns(2)
             
+            # Creating a 2 days delay for the date_input placeholder to be sure there are satellite images in the dataset on app start
             today = datetime.today()
             delay = today - timedelta(days=2)
 
+            # Date input widgets
             col1.warning("Initial NDVI Date 📅")
             initial_date = col1.date_input("initial", value=delay, label_visibility="collapsed")
 
             col2.success("Updated NDVI Date 📅")
             updated_date = col2.date_input("updated", value=delay, label_visibility="collapsed")
 
+            # Setting up the time range variable for an image collection
             time_range = 7
             # Process initial date
             str_initial_start_date, str_initial_end_date = date_input_proc(initial_date, time_range)


### PR DESCRIPTION
**REMAINDER!** Please make your PRs to the *develop* branch, not *streamlit-app* branch.

# Main PR gist

Fixes the date input placeholder that causes absent B8 band while calculating normalized difference with current day dataset that may not include any images.

## Issue ticket

- Issue #29 

## Type of change

Check relevant options and delete options not relevant to this PR:

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Enhancement (maintenance, updating code structure, cleaning up code)
- [ ] This change requires a documentation update

## Changes description

Now the app on start displays a time placeholder with two days delay from the current date in the date input widgets, this ensures that the app don't start fetching an image collection from the current date where the satellite may have not captured any images or the images aren't ingested or added to the dataset yet to avoid running calculations on absent image bands (e. g; absent B8 when calculating normalized difference)

### Checklist

- [x] I have tested these changes locally.
- [x] I have checked the code to ensure it follows the project's coding standards.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added or modified unit tests (if applicable).
- [x] All existing tests pass successfully.

> NOTE: Please delete any section or elements of the PR template that you do not need in your PR submission (including this very note) while maintaining the structure of the template.>